### PR TITLE
Fix casing of targets

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -235,7 +235,7 @@ def evaluate_all(reference_answers, our_answers):
         ref_current = reference_answers[lang]
         for id, prediction in examples.items():
             results[lang][id] = {}
-            targets = ref_current[id]
+            targets = [t.lower() for t in ref_current[id]]
             for metric_name, metric in metrics.items():
                 results[lang][id][metric_name] = metric(prediction, targets)
             results[lang][id]["targets"] = targets


### PR DESCRIPTION
LLM outputs are lowercased as part of the normalization ([here](https://github.com/facebookresearch/multiloko/blob/main/eval.py#L88)), but gold answers are not. This hurts string-based case-sensitive scores where gold answers are capitalized (e.g. exact match and BLEU).