### PR TITLE
Fix three issues preventing the scripts running from a clean checkout

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -297,7 +297,7 @@ def main() -> None:
         if not os.path.isdir(os.path.join(args.dataset_location, lang)):
             continue
         path = os.path.join(args.dataset_location, lang, f"{args.subset}.jsonl")
-        if not path:
+        if not os.path.exists(path):
             continue
         input_parse_tuples.append((path, lang))
         # get translated paths

--- a/examples/create_examples.py
+++ b/examples/create_examples.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import json
 import os
 import pathlib
+import sys
 from typing import List
 from prompts import *
 from utils import jinja_format
@@ -45,7 +46,7 @@ if __name__ == "__main__":
 
     # Load all files
     if not BENCHMARK_DATA.exists():
-        print(f"{BENCHMARK_DATA} not found. Please follow the README instructions and extract the archive.")
+        sys.exit(f"{BENCHMARK_DATA} not found. Please follow the README instructions and extract the archive.")
     else:
         all_examples = {}
         all_examples_translated_machine_english = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sacrebleu
 editdistance
+jinja2


### PR DESCRIPTION
I was setting the repo up from a fresh clone and hit three small snags along the way. None of them affect anyone whose environment already works, but they all get in the way of a first-time setup, so I thought I'd fix them together. Each one is its own commit if you'd rather take them separately.

## `jinja2` is missing from `requirements.txt`

`examples/utils.py` imports it unconditionally, so building an environment from `requirements.txt` alone leaves you a module short:

```
$ python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
$ cd examples && ../.venv/bin/python create_examples.py
ModuleNotFoundError: No module named 'jinja2'
```

Added it to the file.

## The missing-data message gets buried by a traceback

`create_examples.py` prints a genuinely helpful hint when `benchmark_data/` hasn't been extracted yet — but the output-writing block below it sits outside the `else`, so execution carries on and dies a moment later. What you actually see is this:

```
../benchmark_data not found. Please follow the README instructions and extract the archive.
Traceback (most recent call last):
  File "examples/create_examples.py", line 99, in <module>
    for language, examples in all_examples.items():
NameError: name 'all_examples' is not defined
```

The advice is right there, and then a traceback scrolls it off the screen. I switched the `print` to `sys.exit`, which keeps the message and gives you a non-zero status.

## `if not path` never fires

```python
path = os.path.join(args.dataset_location, lang, f"{args.subset}.jsonl")
if not path:
    continue
```

`path` is a string that was just joined, so it's never falsy and the guard never does anything. Languages missing the  requested subset get appended anyway and then blow up later in `parse_input_jsonl`.

That's reachable today rather than hypothetical: seven of the 31 languages have no `extra.jsonl` (bengali, dutch, english, romanian, simplified_mandarin, traditional_mandarin, turkish), so `eval.py -s extra` stops at the first of them:

```
FileNotFoundError: [Errno 2] No such file or directory: 'benchmark_data/romanian/extra.jsonl'
```

Testing `os.path.exists(path)` skips those languages, which I think is what the guard was reaching for. Do say if you'd rather it raised a clearer error instead of skipping quietly — I wasn't sure which you'd prefer, and went with skipping since that seemed to be the original intent.

## What I checked

`eval.py -s dev` over the full extracted dataset scores all 31 languages exactly as before, average EM 0.3399. `eval.py -s extra` now runs over the 24 languages that have that subset rather than raising. `create_examples.py` still generates all 302 prompt files, and now exits 1 with a readable message when the data isn't there.
